### PR TITLE
Manual Modlog Submissions

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -12,7 +12,7 @@ import datetime
 from libs.database import Database
 from libs import utility, moderation
 
-from typing import Optional
+from typing import Optional, List
 
 class Moderation(commands.Cog):
     def __init__(self, bot):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -117,7 +117,7 @@ class Moderation(commands.Cog):
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
         ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
-        attachments: Optonal[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
+        attachments: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -117,7 +117,7 @@ class Moderation(commands.Cog):
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
         ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
-        attachments: Optional[List[nextcord.Attachment]] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
+        attachments: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -116,7 +116,8 @@ class Moderation(commands.Cog):
         reason: Optional[str] = nextcord.SlashOption(required=True, description='Reasoning for dealing punishment'),
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
-        ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident')):
+        ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
+        attachment: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image')):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):
@@ -126,6 +127,7 @@ class Moderation(commands.Cog):
                 duration = 'Permanent'
             additional = {
                     'UUID': uuid,
+                    'Duration': duration,
                     'Platform': platform,
                     'Notes': notes,
                 }
@@ -140,7 +142,7 @@ class Moderation(commands.Cog):
                 recipient = username,
                 reason = reason,
                 additional = additional,
-                enable_attachments = True
+                attachment = attachment
             )
 
             await interaction.send(response, ephemeral=True)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -127,10 +127,12 @@ class Moderation(commands.Cog):
                     'UUID': uuid,
                     'Platform': platform,
                     'Notes': notes,
-                    'Ticket': ticket.mention,
                 }
+            
+            if ticket != None:
+                additional['Ticket'] = ticket.mention
 
-            await moderation.modlog(
+            response = await moderation.modlog(
                 interaction.guild,
                 subject = f'🛠️ Externally {action} User',
                 author = interaction.user,
@@ -140,6 +142,8 @@ class Moderation(commands.Cog):
                 # TODO: Attachments support
                 #attachments = attachments
             )
+
+            await interaction.send(response)
         else:
             await interaction.send(self.cfg['messages']['noperm'])
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -121,6 +121,8 @@ class Moderation(commands.Cog):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):
+            await interaction.response.defer(ephemeral=True)
+
             if duration == None:
                 duration = 'Permanent'
             additional = {
@@ -143,7 +145,7 @@ class Moderation(commands.Cog):
                 #attachments = attachments
             )
 
-            await interaction.send(response)
+            await interaction.send(response, ephemeral=True)
         else:
             await interaction.send(self.cfg['messages']['noperm'])
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -116,8 +116,7 @@ class Moderation(commands.Cog):
         reason: Optional[str] = nextcord.SlashOption(required=True, description='Reasoning for dealing punishment'),
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
-        ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
-        attachments: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
+        ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident')):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):
@@ -141,8 +140,7 @@ class Moderation(commands.Cog):
                 recipient = username,
                 reason = reason,
                 additional = additional,
-                # TODO: Attachments support
-                #attachments = attachments
+                enable_attachments = True
             )
 
             await interaction.send(response, ephemeral=True)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -101,7 +101,7 @@ class Moderation(commands.Cog):
         else:
             await interaction.send(self.cfg['messages']['noperm'])
     
-    @nextcord.slash_command()
+    @nextcord.slash_command(description='Log a punishment from outside of discord')
     async def log(self, interaction: nextcord.Interaction):
         pass
         # Setup for subcommands

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -152,7 +152,8 @@ class Moderation(commands.Cog):
                     attachment3,
                     attachment4,
                     attachment5
-                ]
+                ],
+                manual_log = True
             )
 
             await interaction.send(response, ephemeral=True)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -117,7 +117,7 @@ class Moderation(commands.Cog):
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
         ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
-        attachments: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
+        attachments: Optional[List[nextcord.Attachment]] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -142,7 +142,7 @@ class Moderation(commands.Cog):
                 recipient = username,
                 reason = reason,
                 additional = additional,
-                attachment = attachment
+                attachment = [attachment]
             )
 
             await interaction.send(response, ephemeral=True)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -100,6 +100,48 @@ class Moderation(commands.Cog):
 
         else:
             await interaction.send(self.cfg['messages']['noperm'])
+    
+    @nextcord.slash_command()
+    async def log(self, interaction: nextcord.Interaction):
+        pass
+        # Setup for subcommands
+    
+    @log.subcommand(description='Log a punishment from outside of discord')
+    async def punishment(self, interaction: nextcord.Interaction, 
+        action: Optional[str] = nextcord.SlashOption(required=True, description='Type of punishment dealt',
+            choices = ['Warned', 'Muted', 'Kicked', 'Tempbanned', 'Banned', 'IP Muted', 'IP Tempbanned', 'IP Banned']),
+        username: Optional[str] = nextcord.SlashOption(required=True, description='The user who was punished'),
+        uuid: Optional[str] = nextcord.SlashOption(required=True, description='ID or UUID of the punished player'),
+        platform: Optional[str] = nextcord.SlashOption(required=True, description='Platform the user is on'),
+        reason: Optional[str] = nextcord.SlashOption(required=True, description='Reasoning for dealing punishment'),
+        duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
+        notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
+        ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
+        attachments: Optonal[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Screenshots of evidence or other related information.')):
+        
+        db = Database(interaction.guild, reason='Moderation, log punishment')
+        if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):
+            if duration == None:
+                duration = 'Permanent'
+            additional = {
+                    'UUID': uuid,
+                    'Platform': platform,
+                    'Notes': notes,
+                    'Ticket': ticket.mention,
+                }
+
+            await moderation.modlog(
+                interaction.guild,
+                subject = f'🛠️ Externally {action} User',
+                author = interaction.user,
+                recipient = username,
+                reason = reason,
+                additional = additional,
+                # TODO: Attachments support
+                #attachments = attachments
+            )
+        else:
+            await interaction.send(self.cfg['messages']['noperm'])
 
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -116,7 +116,7 @@ class Moderation(commands.Cog):
         reason: Optional[str] = nextcord.SlashOption(required=True, description='Reasoning for dealing punishment'),
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
-        ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
+        ticket: Optional[nextcord.Thread] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
         attachment1: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),
         attachment2: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),
         attachment3: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -117,7 +117,11 @@ class Moderation(commands.Cog):
         duration: Optional[str] = nextcord.SlashOption(required=False, description='Duration of punishment (if temporary)'),
         notes: Optional[str] = nextcord.SlashOption(required=False, description='Extra Information about the event'),
         ticket: Optional[nextcord.TextChannel] = nextcord.SlashOption(required=False, description='Ticket channel with this incident'),
-        attachment: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image')):
+        attachment1: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),
+        attachment2: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),
+        attachment3: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),
+        attachment4: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),
+        attachment5: Optional[nextcord.Attachment] = nextcord.SlashOption(required=False, description='Upload a relevant image', default=None),):
         
         db = Database(interaction.guild, reason='Moderation, log punishment')
         if interaction.user in db.fetch('admins') or utility.is_mod(interaction.user, db):
@@ -142,7 +146,13 @@ class Moderation(commands.Cog):
                 recipient = username,
                 reason = reason,
                 additional = additional,
-                attachment = [attachment]
+                attachments = [
+                    attachment1,
+                    attachment2,
+                    attachment3,
+                    attachment4,
+                    attachment5
+                ]
             )
 
             await interaction.send(response, ephemeral=True)

--- a/config/help.yml
+++ b/config/help.yml
@@ -193,4 +193,4 @@ applications:
     ## Rejecting Applications
     To close or reject an application, use the `/application close` slash command in the application thread.
     ## Accepting Applications
-    To accept an application, administrators (See the *Admins* help topic) can use the `/application accept` slash command. This will close the thread, and give the applicant the `new_mod_role` you have set.
+    To accept an application, administrators (See the *Admins* help topic) can use the `/application accept` slash command. This will close the thread, and give the applicant the `new_mod_role` if set.

--- a/config/help.yml
+++ b/config/help.yml
@@ -193,4 +193,4 @@ applications:
     ## Rejecting Applications
     To close or reject an application, use the `/application close` slash command in the application thread.
     ## Accepting Applications
-    To accept an application, administrators (See the *Admins* help topic) can use the `/application accept` slash command. This will close the thread, and give the applicant the `staff_role` you have set.
+    To accept an application, administrators (See the *Admins* help topic) can use the `/application accept` slash command. This will close the thread, and give the applicant the `new_mod_role` you have set.

--- a/config/help.yml
+++ b/config/help.yml
@@ -193,4 +193,4 @@ applications:
     ## Rejecting Applications
     To close or reject an application, use the `/application close` slash command in the application thread.
     ## Accepting Applications
-    To accept an application, administrators (See the *Admins* help topic) can use the `/application accept` slash command. This will close the thread, and give the applicant the `new_mod_role` if set.
+    To accept an application, administrators (See the *Admins* help topic) can use the `/application accept` slash command. This will close the thread, DM the user that they have been accepted, and give the applicant the `new_mod_role` if set.

--- a/config/help.yml
+++ b/config/help.yml
@@ -17,7 +17,11 @@ main:
     - *Admins*: How to manage [[BOT]] administrators
     - *Settings*: How to change settings for the bot, and what different settings do:
     - *Utilities*: Info on various utility commands
-    - *Fun Commands*: Various entertainment  commands and what they do
+    - *Fun Commands*: Various entertainment commands and what they do
+    - *Permissions*: How [[BOT]] permissions work
+    - *Ticket System*: How to set up and use the ticketing system
+    - *Levels*: How to set up or disable the levelling system
+    - *Mod Applications*: How to set up and use the mod applications system
 
 welcome:
   name: Welcome Messages
@@ -81,15 +85,20 @@ setting:
     - `system_channel`: The channel to show join/leave messages in
     - `announcement_channel`: The channel to put announcements from the `/announce` command in
     - `announcement_role`: The role to mention when pings are enabled in the `/announce` command
+    - `modlog_channel`: Channel to put modlog messages in
+    - `manual_modlog_channel`: Channel to put modlog messages in when submitted manually (i.e. via `/log punishment`). If not set uses `modlog_channel`
     - `staff_role`: The role for all staff members. Users with this role can perform moderation actions, and this role is given to users automatically when their application is accepted by an administrator.
     - `bugreports_channel`: The channel to post bug reports in from the `/report bug` command
     - `bugreports_questions`: A semicolon (`;`) separated list of questions for the bug reports modal.
     - `ip_address`: the IP address to show in the `/ip` command
     - `ip_text`: An extended description for the `/ip` command
     - `ip_game`: The name of the game `/ip` is for
+    - `ticket_channel`: Channel to make tickets in
+    - `transcript_channel`: Channel to post ticket closed messages in (uses `modlog_channel` by default)
+    - `log_channel`: Channel to log message edits, deletions, vc movements, and other user actions in
+    - 'no_points_channels'
     - `application_channel`: the channel to create application private threads in
     - `application_questions`: A semicolon (`;`) separated list of questions to ask applicants. See the *Mod Applications* section for the default list of questions.
-
 
 utility:
   name: Utilities

--- a/config/help.yml
+++ b/config/help.yml
@@ -99,6 +99,7 @@ setting:
     - 'no_points_channels'
     - `application_channel`: the channel to create application private threads in
     - `application_questions`: A semicolon (`;`) separated list of questions to ask applicants. See the *Mod Applications* section for the default list of questions.
+    - `new_mod_role`: Role to give new moderators, See the *Mod Applications* help topic
 
 utility:
   name: Utilities

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,7 @@ settings:
   - 'announcement_role'
   - 'staff_role'
   - 'modlog_channel'
+  - 'manual_modlog_channel'
   - 'bugreports_channel'
   - 'bugreports_questions'
   - 'ip_address'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@ settings:
   - 'no_points_channels'
   - 'application_channel'
   - 'application_questions'
+  - 'new_mod_role'
 
 # Internal data that cannot be changed by the user.
 hidden:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,6 @@ settings:
   - 'ip_address'
   - 'ip_text'
   - 'ip_game'
-  - 'application_channel'
   - 'ticket_channel'
   - 'transcript_channel'
   - 'log_channel'

--- a/libs/applications.py
+++ b/libs/applications.py
@@ -230,7 +230,7 @@ async def accept(interaction: nextcord.Interaction):
 
         creator = await get_applicant(thread)
         await interaction.send(f'**✅ Application Accepted!**')
-        await thread.edit(name=f'{thread.name} [Closed]', archived=True, locked=True)
+        await thread.edit(name=f'{thread.name} [Accepted]', archived=True, locked=True)
         if mod_role != None:
             try:
                 await creator.add_roles(mod_role)

--- a/libs/applications.py
+++ b/libs/applications.py
@@ -218,12 +218,11 @@ async def accept(interaction: nextcord.Interaction):
             return
 
         try:
-            staff_role = interaction.guild.get_role(int(db.fetch('staff_role')))
-            if staff_role == None:
+            mod_role = interaction.guild.get_role(int(db.fetch('new_mod_role')))
+            if mod_role == None:
                 raise ValueError
         except ValueError:
-            await interaction.send('The `staff_role` setting must be set to use this command.', ephemeral=True)
-            return
+            mod_role = None
 
         thread = interaction.channel
         user = interaction.user
@@ -232,10 +231,11 @@ async def accept(interaction: nextcord.Interaction):
         creator = await get_applicant(thread)
         await interaction.send(f'**✅ Application Accepted!**')
         await thread.edit(name=f'{thread.name} [Closed]', archived=True, locked=True)
-        try:
-            await creator.add_roles(staff_role)
-        except nextcord.errors.Forbidden:
-            await thread.send(f'I do not have permission to give out the `staff_role`! You will have to apply it manually.\nMake sure I have a role above it in the hirearchy.')
+        if mod_role != None:
+            try:
+                await creator.add_roles(mod_role)
+            except nextcord.errors.Forbidden:
+                await thread.send(f'I do not have permission to give out the `new_mod_role`! You will have to apply it manually.\nMake sure I have a role above it in the hirearchy.')
         await creator.send(f'**Welcome to the {thread.guild.name} Staff Team**\nYour application, {thread.name} has been accepted!. You can view it here: {thread.mention}.\n\
 Now that you\'re a moderator, you may want to read the moderator guide: <https://github.com/RoseSMP/.github/blob/main/Tiramisu/moderator-guide.md>')
         await moderation.modlog(interaction.guild, '✅ Application Accepted', interaction.user, creator, additional = {'Thread':thread.mention})

--- a/libs/buttons.py
+++ b/libs/buttons.py
@@ -76,13 +76,3 @@ class ApplicationActions(nextcord.ui.View):
         await applications.close(interaction)
         self.clear_items()
 
-class ModlogAttachmentButtons(nextcord.ui.View):
-    def __init__(self):
-        """ Buttons for adding/clearing attachments on a message in the modlog """
-        super().__init__(timeout=None)
-    
-    @nextcord.ui.button(label='Add Attachment', emoji='📸', custom_id='tiramisu:modlog_add_attachment', style=nextcord.ButtonStyle.primary)
-    async def on_add(self, button: nextcord.ui.Button, interaction: nextcord.Interaction):
-        # Add attachment
-        message = await interaction.original_message()
-        

--- a/libs/buttons.py
+++ b/libs/buttons.py
@@ -75,3 +75,14 @@ class ApplicationActions(nextcord.ui.View):
     async def on_close(self, button, interaction: nextcord.Interaction):
         await applications.close(interaction)
         self.clear_items()
+
+class ModlogAttachmentButtons(nextcord.ui.View):
+    def __init__(self):
+        """ Buttons for adding/clearing attachments on a message in the modlog """
+        super().__init__(timeout=None)
+    
+    @nextcord.ui.button(label='Add Attachment', emoji='📸', custom_id='tiramisu:modlog_add_attachment', style=nextcord.ButtonStyle.primary)
+    async def on_add(self, button: nextcord.ui.Button, interaction: nextcord.Interaction):
+        # Add attachment
+        message = await interaction.original_message()
+        

--- a/libs/logging.py
+++ b/libs/logging.py
@@ -115,6 +115,7 @@ class ChangeVoice(LoggingEvent):
             action = 'Turned __ON__ Camera in'
             use = after
         else:
+            action = 'Null'
             self.void = True # Its some other change we don't want to report
         
         super().__init__(

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -125,7 +125,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
             await channel.send(message)
 
         return f"*Successfully logged action in {channel.mention}.*"
-    except nextcord.HTTPException:
+    except nextcord.Forbidden:
         return f"*Failed to log action. I do not have permission to send messages in {channel.mention}*"
     except BaseException as e:
         if hasattr(e, 'message'):

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -88,7 +88,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         db.close()
 
     try:
-        await channel.send(message, files = attachments)
+        await channel.send(message)#, files = attachments)
         return f"*Successfully logged action in {channel.mention}.*"
     except nextcord.HTTPException:
         return f"*Failed to log action. I do not have permission to send messages in {channel.mention}*"

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -13,11 +13,11 @@ import uuid
 import time
 
 from libs.database import Database
-from libs import utility, mod_database
+from libs import utility, mod_database, buttons
 
 async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: Union[str, nextcord.User], additional: dict = {}, 
     reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False,
-    attachments: None = Optional[Union[nextcord.File, List[nextcord.File]]]):
+    enable_attachments: bool = False):
     """ Send a Message in the `modlog_channel` channel
     Parameters:
      - `guild`: nextcord.Guild, which guild this message is for
@@ -31,6 +31,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
      - `action`: optional str, default None, if set the action is logged in the Database and this is used in the action column
      - `ticket`: optional bool, default False, if the modlog action is a ticket. If it is, the message is sent in the `transcript_channel` channel instead, if it is set.
                     The reason is also not shown when `ticket` is enabled.
+     - `enable_attachments`: optional bool, default False, whether to add the buttons that allow moderators to add/clear attachments.
     Returns:
      - `str`: A message about whether this action was successful, to be put in the interaction response message """
     
@@ -88,7 +89,11 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         db.close()
 
     try:
-        await channel.send(message)#, files = attachments)
+        if enable_attachments:
+            await channel.send(message, view = buttons.ModlogAttachmentButtons())
+        else:
+            await channel.send(message)
+
         return f"*Successfully logged action in {channel.mention}.*"
     except nextcord.HTTPException:
         return f"*Failed to log action. I do not have permission to send messages in {channel.mention}*"

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -114,8 +114,8 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                             response += f': {e}*'
                         return response
                 
-                file_list.append(file)
-                file_paths.append(filepath)
+                    file_list.append(file)
+                    file_paths.append(filepath)
 
             await channel.send(message, files=file_list)
             

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -91,7 +91,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
     try:
         if attachment != None:
             try:
-                file = nextcord.File(attachment.read())
+                file = nextcord.File(await attachment.read())
             except Exception as e:
                 response = '*Failed to log action. Could not process attachment'
                 if hasattr(e, 'message'):

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -63,7 +63,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         if action != None:
             logger.warning(f'`action` was passed to modlog when `recipient` was a str! Disabling.')
             action = None
-    if show_recipient:
+    elif show_recipient:
         recipient_display = f'\n**User:** {escape_markdown(recipient.display_name)} || {escape_markdown(recipient.name)}, `{recipient.id}` ||'
     else:
         recipient_display = ''

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -110,7 +110,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                     response += f': {e}*'
                 return response
 
-            await channel.send(message, attachment = file)
+            await channel.send(message, files=[file])
             
             os.remove(filepath)
         else:    

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -98,6 +98,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                     response += f': {e}: {e.message}*'
                 else:
                     response += f': {e}*'
+                return response
             await channel.send(message, attachment = file)
         else:    
             await channel.send(message)

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -91,7 +91,8 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
     try:
         if attachment != None:
             try:
-                file = nextcord.File(await attachment.read())
+                file = nextcord.File(await attachment.read(), attachment.filename, 
+                    description=attachment.description, spoiler=attachment.is_spoiler())
             except Exception as e:
                 response = '*Failed to log action. Could not process attachment'
                 if hasattr(e, 'message'):

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -114,7 +114,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                             response += f': {e}*'
                         return response
                 
-                file_list.append(file_list)
+                file_list.append(file)
                 file_paths.append(filepath)
 
             await channel.send(message, files=file_list)

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -11,6 +11,7 @@ from typing import Optional, Union, List
 import json
 import uuid
 import time
+import os
 
 from libs.database import Database
 from libs import utility, mod_database, buttons
@@ -91,7 +92,13 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
     try:
         if attachment != None:
             try:
-                file = nextcord.File(await attachment.read(), attachment.filename, 
+                cachedir = f'./.cache/'
+                os.mkdir(cachedir)
+                filepath = f'{cachedir}/{attachment.id}-{attachment.filename}'
+                with open(filepath, 'w') as fp:
+                    await attachment.save(fp)
+
+                file = nextcord.File(filepath, attachment.filename, 
                     description=attachment.description, spoiler=attachment.is_spoiler())
             except Exception as e:
                 response = '*Failed to log action. Could not process attachment'
@@ -100,7 +107,11 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                 else:
                     response += f': {e}*'
                 return response
+
+
             await channel.send(message, attachment = file)
+
+            os.remove(filepath)
         else:    
             await channel.send(message)
 

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -6,7 +6,7 @@
 from logging42 import logger
 import nextcord
 from nextcord.utils import escape_markdown
-from typing import Union, List
+from typing import Optional, Union, List
 
 import json
 import uuid
@@ -17,7 +17,7 @@ from libs import utility, mod_database
 
 async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: Union[str, nextcord.User], additional: dict = {}, 
     reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False,
-    attachments: None = List[nextcord.File]):
+    attachments: None = Optional[Union[nextcord.File, List[nextcord.File]]]):
     """ Send a Message in the `modlog_channel` channel
     Parameters:
      - `guild`: nextcord.Guild, which guild this message is for

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -18,7 +18,7 @@ from libs import utility, mod_database, buttons
 
 async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: Union[str, nextcord.User], additional: dict = {}, 
     reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False,
-    attachments: Optional[List[nextcord.Attachment]] = None):
+    attachments: Optional[List[nextcord.Attachment]] = None, manual_log: bool = False):
     """ Send a Message in the `modlog_channel` channel
     Parameters:
      - `guild`: nextcord.Guild, which guild this message is for
@@ -33,6 +33,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
      - `ticket`: optional bool, default False, if the modlog action is a ticket. If it is, the message is sent in the `transcript_channel` channel instead, if it is set.
                     The reason is also not shown when `ticket` is enabled.
      - `attachments`: optional List[nextcord.Attachment], default None, an attachment to add
+     - `manual_log`: optional bool, default False, if modlog message was manually submitted (so it can be put in `manual_modlog_channel` if set)
     Returns:
      - `str`: A message about whether this action was successful, to be put in the interaction response message """
     
@@ -42,6 +43,14 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
     if ticket:
         try:
             channel = guild.get_channel(int( db.fetch('transcript_channel') ))
+            if channel == None:
+                raise ValueError
+        except ValueError:
+            channel = None
+    
+    if manual_log:
+        try:
+            channel = guild.get_channel(int( db.fetch('manual_modlog_channel') ))
             if channel == None:
                 raise ValueError
         except ValueError:

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -18,7 +18,7 @@ from libs import utility, mod_database, buttons
 
 async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: Union[str, nextcord.User], additional: dict = {}, 
     reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False,
-    attachment: Optional[List[nextcord.Attachment]] = None):
+    attachments: Optional[List[nextcord.Attachment]] = None):
     """ Send a Message in the `modlog_channel` channel
     Parameters:
      - `guild`: nextcord.Guild, which guild this message is for
@@ -32,7 +32,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
      - `action`: optional str, default None, if set the action is logged in the Database and this is used in the action column
      - `ticket`: optional bool, default False, if the modlog action is a ticket. If it is, the message is sent in the `transcript_channel` channel instead, if it is set.
                     The reason is also not shown when `ticket` is enabled.
-     - `attachment`: optional List[nextcord.Attachment], default None, an attachment to add
+     - `attachments`: optional List[nextcord.Attachment], default None, an attachment to add
     Returns:
      - `str`: A message about whether this action was successful, to be put in the interaction response message """
     
@@ -94,24 +94,25 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
             file_list = []
             file_paths = []
             for attachment in attachments:
-                try:
-                    cachedir = f'./.cache/'
+                if attachment != None:
                     try:
-                        os.mkdir(cachedir)
-                    except FileExistsError:
-                        pass
-                    filepath = f'{cachedir}/{attachment.id}-{attachment.filename}'
-                    await attachment.save(filepath)
+                        cachedir = f'./.cache/'
+                        try:
+                            os.mkdir(cachedir)
+                        except FileExistsError:
+                            pass
+                        filepath = f'{cachedir}/{attachment.id}-{attachment.filename}'
+                        await attachment.save(filepath)
 
-                    file = nextcord.File(filepath, attachment.filename, 
-                        description=attachment.description, spoiler=attachment.is_spoiler())
-                except Exception as e:
-                    response = '*Failed to log action. Could not process attachment'
-                    if hasattr(e, 'message'):
-                        response += f': {e}: {e.message}*'
-                    else:
-                        response += f': {e}*'
-                    return response
+                        file = nextcord.File(filepath, attachment.filename, 
+                            description=attachment.description, spoiler=attachment.is_spoiler())
+                    except Exception as e:
+                        response = '*Failed to log action. Could not process attachment'
+                        if hasattr(e, 'message'):
+                            response += f': {e}: {e.message}*'
+                        else:
+                            response += f': {e}*'
+                        return response
                 
                 file_list.append(file_list)
                 file_paths.append(filepath)

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -105,8 +105,12 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         return f"*Successfully logged action in {channel.mention}.*"
     except nextcord.HTTPException:
         return f"*Failed to log action. I do not have permission to send messages in {channel.mention}*"
-    except:
-        return f'*Failed to log action. Could not send message to {channel.mention}.*'
+    except BaseException as e:
+        if hasattr(e, 'message'):
+            extra = f'\n*{e}: {e.message}*'
+        else:
+            extra = f' *({e})*'
+        return f'*Failed to log action. Could not send message to {channel.mention}.*{extra}'
 
 
 async def kick(interaction: nextcord.Interaction, user, reason, dm=True):

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -6,6 +6,7 @@
 from logging42 import logger
 import nextcord
 from nextcord.utils import escape_markdown
+from typing import Union, List
 
 import json
 import uuid
@@ -14,14 +15,15 @@ import time
 from libs.database import Database
 from libs import utility, mod_database
 
-async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: nextcord.User, additional: dict = {}, 
-    reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False):
+async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: Union[str, nextcord.User], additional: dict = {}, 
+    reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False,
+    attachments: None = List[nextcord.File]):
     """ Send a Message in the `modlog_channel` channel
     Parameters:
      - `guild`: nextcord.Guild, which guild this message is for
      - `subject`: bold heading in messages
      - `author`: nextcord.User, who performed the action
-     - `recipient`: nextcord.User, who the action was performed on
+     - `recipient`: nextcord.User or str, who the action was performed on
      - `additional`: optional dict, added fields for the message
      - `reason`: optional str, why this action was performed
      - `moderator`: optional bool, default True, set to false if the author is not a moderator.
@@ -81,7 +83,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         db.close()
 
     try:
-        await channel.send(message)
+        await channel.send(message, files = attachments)
         return f"*Successfully logged action in {channel.mention}.*"
     except nextcord.HTTPException:
         return f"*Failed to log action. I do not have permission to send messages in {channel.mention}*"

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -58,6 +58,11 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
     else:
         author_title = 'Author'
     
+    if type(recipient) is str:
+        recipient_display = f'\n**User:** {escape_markdown(recipient)}'
+        if action != None:
+            logger.warning(f'`action` was passed to modlog when `recipient` was a str! Disabling.')
+            action = None
     if show_recipient:
         recipient_display = f'\n**User:** {escape_markdown(recipient.display_name)} || {escape_markdown(recipient.name)}, `{recipient.id}` ||'
     else:
@@ -69,7 +74,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
 
     for key in additional:
         message += f'\n**{key}:** {additional[key]}'
-    
+
     if action != None:
         mod_database.log(db, 
             int(round(time.time() * 1000)), # timestamp

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -95,8 +95,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                 cachedir = f'./.cache/'
                 os.mkdir(cachedir)
                 filepath = f'{cachedir}/{attachment.id}-{attachment.filename}'
-                with open(filepath, 'w') as fp:
-                    await attachment.save(fp)
+                await attachment.save(filepath)
 
                 file = nextcord.File(filepath, attachment.filename, 
                     description=attachment.description, spoiler=attachment.is_spoiler())
@@ -107,7 +106,6 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                 else:
                     response += f': {e}*'
                 return response
-
 
             await channel.send(message, attachment = file)
 

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -93,7 +93,10 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         if attachment != None:
             try:
                 cachedir = f'./.cache/'
-                os.mkdir(cachedir)
+                try:
+                    os.mkdir(cachedir)
+                except FileExistsError:
+                    pass
                 filepath = f'{cachedir}/{attachment.id}-{attachment.filename}'
                 await attachment.save(filepath)
 
@@ -108,7 +111,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
                 return response
 
             await channel.send(message, attachment = file)
-
+            
             os.remove(filepath)
         else:    
             await channel.send(message)

--- a/libs/moderation.py
+++ b/libs/moderation.py
@@ -17,7 +17,7 @@ from libs import utility, mod_database, buttons
 
 async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, recipient: Union[str, nextcord.User], additional: dict = {}, 
     reason: str = 'No reason specified.', moderator: bool = True, show_recipient: bool = True, action: str = None, ticket: bool = False,
-    enable_attachments: bool = False):
+    attachment: Optional[nextcord.Attachment] = None):
     """ Send a Message in the `modlog_channel` channel
     Parameters:
      - `guild`: nextcord.Guild, which guild this message is for
@@ -31,7 +31,7 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
      - `action`: optional str, default None, if set the action is logged in the Database and this is used in the action column
      - `ticket`: optional bool, default False, if the modlog action is a ticket. If it is, the message is sent in the `transcript_channel` channel instead, if it is set.
                     The reason is also not shown when `ticket` is enabled.
-     - `enable_attachments`: optional bool, default False, whether to add the buttons that allow moderators to add/clear attachments.
+     - `attachment`: optional nextcord.Attachment, default None, an attachment to add
     Returns:
      - `str`: A message about whether this action was successful, to be put in the interaction response message """
     
@@ -89,9 +89,17 @@ async def modlog(guild: nextcord.Guild, subject: str, author: nextcord.User, rec
         db.close()
 
     try:
-        if enable_attachments:
-            await channel.send(message, view = buttons.ModlogAttachmentButtons())
-        else:
+        if attachment != None:
+            try:
+                file = nextcord.File(attachment.read())
+            except Exception as e:
+                response = '*Failed to log action. Could not process attachment'
+                if hasattr(e, 'message'):
+                    response += f': {e}: {e.message}*'
+                else:
+                    response += f': {e}*'
+            await channel.send(message, attachment = file)
+        else:    
             await channel.send(message)
 
         return f"*Successfully logged action in {channel.mention}.*"


### PR DESCRIPTION
Add command (`/log punishment`) to allow moderators to manually send items to the modlog channel. 