### PR TITLE
Tell users the server IP + remove settings choices

### DIFF
--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -89,7 +89,9 @@ class Settings(commands.Cog):
                     page_note = '\n'
                     if page > 1:
                         page_note += f'**←** `all:{page - 1}` | '
-                    page_note += f'*Page {page} of {len(pagination)}* | `all:{page + 1}` **→**'
+                    page_note += f'*Page {page} of {len(pagination)}*'
+                    if page < len(pagination):
+                        page_note += f' | `all:{page + 1}` **→**'
 
                 else:
                     show_settings = all_settings

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -78,7 +78,7 @@ class Settings(commands.Cog):
         db = Database(interaction.guild, reason='Slash command `/setting set`')
         if interaction.user.id in db.fetch('admins'):
             setting = setting.strip()
-            if setting not in SETTINGS:
+            if setting not in self.settings['settings']:
                 valid = False
             else:
                 valid, new_value, response = utility.valid_setting(interaction.guild, setting, value)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -84,7 +84,7 @@ class Settings(commands.Cog):
                     page_note = '\n'
                     if page > 1:
                         page_note += f'**←** `all:{page - 1}` | '
-                    page_note += f'*Page {page} of {len(pagination)} | `all:{page + 1}` **→**'
+                    page_note += f'*Page {page} of {len(pagination)}* | `all:{page + 1}` **→**'
 
                 else:
                     show_settings = all_settings

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -92,6 +92,7 @@ class Settings(commands.Cog):
 
                 for entry in show_settings:
                     message += f'• `{entry}`\n'
+                message += page_note
             else:
                 message = 'No such setting. Use `all` to get a list of all available settings'
             await interaction.send(message)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -41,7 +41,7 @@ class Settings(commands.Cog):
 
     @setting.subcommand(description='View settings')
     async def get(self, interaction: nextcord.Interaction, 
-        setting: Optional[str] = nextcord.SlashOption(description='Which setting to view. Use "all" to get a list of available options.', required=True, choices=SETTINGS + ['all'])):
+        setting: Optional[str] = nextcord.SlashOption(description='Which setting to view. Use "all" to get a list of available options.', required=True, )): #choices=SETTINGS + ['all'])):
         db = Database(interaction.guild, reason='Slash command `/setting get`')
         if interaction.user.id in db.fetch('admins'):
             if setting in self.settings['settings'] + extensions.get_all_shown_settings():
@@ -73,11 +73,15 @@ class Settings(commands.Cog):
     
     @setting.subcommand(description='Change settings')
     async def set(self, interaction: nextcord.Interaction,
-        setting: Optional[str] = nextcord.SlashOption(description='Which setting to change', required=True, choices=SETTINGS),
+        setting: Optional[str] = nextcord.SlashOption(description='Which setting to change', required=True, ), #choices=SETTINGS),
         value: Optional[str] = nextcord.SlashOption(description='What to change it to', default='none')):
         db = Database(interaction.guild, reason='Slash command `/setting set`')
         if interaction.user.id in db.fetch('admins'):
-            valid, new_value, response = utility.valid_setting(interaction.guild, setting, value)
+            setting = setting.strip()
+            if setting not in SETTINGS:
+                valid = False
+            else:
+                valid, new_value, response = utility.valid_setting(interaction.guild, setting, value)
 
             if valid:
                 db.set(setting, new_value)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -61,9 +61,36 @@ class Settings(commands.Cog):
                 except ValueError:
                     pass
                 message = f'Setting **{setting}** is currently set to __{value}__'
-            elif setting == 'all':
+            elif setting.startswith('all'):
                 message = f'**Available settings:**\n'
-                for entry in self.settings['settings'] + extensions.get_all_shown_settings():
+                if setting.strip() == 'all':
+                    page = 1
+                else:
+                    try:
+                        page = int(setting.split(':')[-1])
+                    except ValueError:
+                        page = 1
+                
+                all_settings = self.settings['settings'] + extensions.get_all_shown_settings()
+                
+                if len(all_settings) > 15:
+                    pagination = []
+                    n = 10 # Settings per page
+                    # https://stackoverflow.com/a/312464/
+                    for i in range(0, len(all_settings), n):
+                        pagination.append(all_settings[i:i + n])
+                    show_settings = pagination[page - 1]
+                    
+                    page_note = '\n'
+                    if page > 1:
+                        page_note += f'**←** `all:{page - 1}` | '
+                    page_note += f'*Page {page} of {len(pagination)} | `all:{page + 1}` **→**'
+
+                else:
+                    show_settings = all_settings
+                    page_note = ''
+
+                for entry in show_settings:
                     message += f'• `{entry}`\n'
             else:
                 message = 'No such setting. Use `all` to get a list of all available settings'

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -79,6 +79,11 @@ class Settings(commands.Cog):
                     # https://stackoverflow.com/a/312464/
                     for i in range(0, len(all_settings), n):
                         pagination.append(all_settings[i:i + n])
+                    
+                    if page > len(pagination):
+                        page = len(pagination)
+                    elif page <= 0:
+                        page = 1
                     show_settings = pagination[page - 1]
                     
                     page_note = '\n'

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -80,6 +80,7 @@ class Settings(commands.Cog):
             setting = setting.strip()
             if setting not in self.settings['settings']:
                 valid = False
+                response = 'That is not a valid setting. Use `/setting get:all` to see all available settings.'
             else:
                 valid, new_value, response = utility.valid_setting(interaction.guild, setting, value)
 

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -21,7 +21,7 @@ class Utilities(commands.Cog):
         with open("config/config.yml", "r") as ymlfile:
             self.cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
         
-        ip_regex = '(?i)[Ww]hat.+[Ii][Pp]|[Hh]ow.+[Jj]oin|to.+[Jj]oin|[Ss]erver.+[Aa]ddress|[Ii]nto.+[SMPsmp]'
+        ip_regex = '(?i)what.+ip|how.+join|to.+join|server.+address|into.+smp'
         self.ip_regex = re.compile(ip_regex)
     
 
@@ -35,7 +35,7 @@ class Utilities(commands.Cog):
         """ Auto-Reply to people asking for the IP if specified. See `ip_answer_channels` in config/help.yml """
         if not message.author.bot and message.guild != None:
             db = Database(message.guild, reason='Utilites/IP Regex')
-            if str(message.channel.id) in db.fetch('ip_answer_channels') and self.ip_regex.match(message.content) != None:
+            if str(message.channel.id) in db.fetch('ip_answer_channels') and self.ip_regex.search(message.content) != None:
                 await message.reply(utility.ip_message(db))
 
     # Commands

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -8,39 +8,41 @@ from logging42 import logger
 import nextcord
 from nextcord.ext import commands
 
+import re
 import yaml
 from typing import Optional
 
 from libs.database import Database
+from libs import utility
 
 class Utilities(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         with open("config/config.yml", "r") as ymlfile:
             self.cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
+        
+        ip_regex = '(?i)[Ww]hat.+[Ii][Pp]|[Hh]ow.+[Jj]oin|to.+[Jj]oin|[Ss]erver.+[Aa]ddress|[Ii]nto.+[SMPsmp]'
+        self.ip_regex = re.compile(ip_regex)
     
 
     # Events
     @commands.Cog.listener()
     async def on_ready(self):
         logger.info('Loaded cog utilities.py')
+    
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        """ Auto-Reply to people asking for the IP if specified. See `ip_answer_channels` in config/help.yml """
+        if not message.author.bot and message.guild != None:
+            db = Database(message.guild, reason='Utilites/IP Regex')
+            if str(message.channel.id) in db.fetch('ip_answer_channels') and self.ip_regex.match(message.content) != None:
+                await message.reply(utility.ip_message(db))
 
     # Commands
     @nextcord.slash_command(description="Get the game server IP")
     async def ip(self, interaction: nextcord.Interaction):
         db = Database(interaction.guild, reason='Slash command `/ip`')
-        ip = db.fetch('ip_address')
-        text = db.fetch('ip_text')
-        game = db.fetch('ip_game')
-        warn = ''
-        if ip == 'none':
-            warn += '\nAsk the admins to change the setting `ip_address`'
-        if text == 'none':
-            text = ''
-            warn += '\nAsk the admins to change the setting `ip_text` to show a description.'
-        if game == 'none':
-            warn += '\nAsk the admins to change the setting `ip_game` to which game their server is for.'
-        await interaction.send(f'**{game.title()} Server IP:** `{ip}`\n{text}{warn}')
+        await interaction.send(utility.ip_message(db))
     
     @nextcord.slash_command(description='Give all users a specific role')
     async def addrole(self, interaction: nextcord.Interaction,

--- a/config/help.yml
+++ b/config/help.yml
@@ -79,7 +79,7 @@ setting:
     When setting an channel or role, always @mention or #mention the role or channel. You can also use the ID if preferred.
     The second part of the setting after the underscore tells you what kind of input it needs.
     ## Checking Settings
-    You can check what different settings are currently set to with the `/setting get` command. You can also use `/setting get setting:all` to get a list of all available settings.
+    You can check what different settings are currently set to with the `/setting get` command. __You can also use `/setting get setting:all` to get a list of all available settings.__
     ## Available Settings
     Below is a list of some of the available settings and what they do:
     - `system_channel`: The channel to show join/leave messages in

--- a/config/help.yml
+++ b/config/help.yml
@@ -93,6 +93,7 @@ setting:
     - `ip_address`: the IP address to show in the `/ip` command
     - `ip_text`: An extended description for the `/ip` command
     - `ip_game`: The name of the game `/ip` is for
+    - `ip_answer_channels`: A list of channels in which the bot should respond with IP information when people ask things like "What's the IP?" or "How do I join the SMP?".
     - `ticket_channel`: Channel to make tickets in
     - `transcript_channel`: Channel to post ticket closed messages in (uses `modlog_channel` by default)
     - `log_channel`: Channel to log message edits, deletions, vc movements, and other user actions in

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@ settings:
   - 'ip_address'
   - 'ip_text'
   - 'ip_game'
+  - 'ip_answer_channels'
   - 'ticket_channel'
   - 'transcript_channel'
   - 'log_channel'

--- a/doc/utility-lib.md
+++ b/doc/utility-lib.md
@@ -43,3 +43,12 @@ Returns a Tuple:
 - `bool`: whether the value is acceptable
 - `value`: the value as it should be sent to the database, None if it is unacceptable
 - `message`: a message to inform the user about what happened, if an error took place. Otherwise, it's an empty string.
+
+### ip_message
+Creates the message for the `/ip` command and auto-reply feature.
+
+Parameters:
+- `db`: a `libs.database.Database` connection to fetch settings with
+
+Returns:
+- `str`: the text of the message that should be sent.

--- a/libs/utility.py
+++ b/libs/utility.py
@@ -10,7 +10,7 @@ import yaml
 import shutil
 import sys
 
-from libs import extensions
+from libs import extensions, database
 
 
 def error_unexpected(error, name='unknown file'):
@@ -182,3 +182,16 @@ def verify_config(repair: Optional[bool] = True):
         sys.exit()
         
     
+def ip_message(db: database.Database)  -> str:
+    ip = db.fetch('ip_address')
+    text = db.fetch('ip_text')
+    game = db.fetch('ip_game')
+    warn = ''
+    if ip == 'none':
+        warn += '\n*Ask the admins to change the setting `ip_address`*'
+    if text == 'none':
+        text = ''
+        warn += '\n*Ask the admins to change the setting `ip_text` to show a description.*'
+    if game == 'none':
+        warn += '\n*Ask the admins to change the setting `ip_game` to which game their server is for.*'
+    return f'**{game.title()} Server IP:** `{ip}`\n{text}{warn}'


### PR DESCRIPTION
Uses regex to reply to users with the content of the /ip command, in channels listed in the `ip_answer_channels` setting.

Also, since this raises the number of settings above what discord allows for choices to a command, those choices have been removed from the slash command option. 
Users are instructed to use `/setting get all` to see all settings if the setting they specify in `/setting set` doesnt exist.